### PR TITLE
[1589][IMP] stock_quant_manual_assign: split domain into a method

### DIFF
--- a/stock_quant_manual_assign/__manifest__.py
+++ b/stock_quant_manual_assign/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Stock - Manual Quant Assignment",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.1",
     "category": "Warehouse",
     "license": "AGPL-3",
     "author": "AvanzOSC, "

--- a/stock_quant_manual_assign/wizard/assign_manual_quants.py
+++ b/stock_quant_manual_assign/wizard/assign_manual_quants.py
@@ -61,14 +61,23 @@ class AssignManualQuants(models.TransientModel):
         return {}
 
     @api.model
-    def default_get(self, fields):
-        res = super(AssignManualQuants, self).default_get(fields)
-        move = self.env['stock.move'].browse(self.env.context['active_id'])
-        available_quants = self.env['stock.quant'].search([
+    def _domain_for_available_quants(self, move):
+        return [
             ('location_id', 'child_of', move.location_id.id),
             ('product_id', '=', move.product_id.id),
             ('quantity', '>', 0),
-        ])
+        ]
+
+    @api.model
+    def _get_available_quants(self, move):
+        domain = self._domain_for_available_quants(move)
+        return self.env['stock.quant'].search(domain)
+
+    @api.model
+    def default_get(self, fields):
+        res = super(AssignManualQuants, self).default_get(fields)
+        move = self.env['stock.move'].browse(self.env.context['active_id'])
+        available_quants = self._get_available_quants(move)
         quants_lines = []
         for quant in available_quants:
             line = {}


### PR DESCRIPTION
[1589](https://www.quartile.co/web#id=1589&action=771&model=project.task&view_type=form&menu_id=505)

This is to make it easier to manipulate with the domain conditions and the search result for available quants.

I will make a corresponding PR to the OCA repo.