### PR TITLE
st1 [1701][FIX] sale_partner_incoterm: switch to extend the standard method

### DIFF
--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -8,14 +8,16 @@ from odoo import models, api
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.onchange("partner_shipping_id", "partner_shipping_id")
-    def onchange_partner_id_incoterm(self):
+    @api.onchange("partner_shipping_id", "partner_id")
+    def onchange_partner_shipping_id(self):
+        res = super().onchange_partner_shipping_id()
         if not self.partner_shipping_id:
             self.incoterm = False
-            return
+            return res
         self.incoterm = self.partner_shipping_id.sale_incoterm_id
         if not self.incoterm:
             if not self.partner_id:
                 self.incoterm = False
-                return
+                return res
             self.incoterm = self.partner_id.sale_incoterm_id
+        return res

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -29,18 +29,18 @@ class TestSalePartnerIncoterm(TransactionCase):
         )
         # No incoterm on either partner
         sale_order = self.env["sale.order"].create({"partner_id": customer_1.id})
-        sale_order.onchange_partner_id_incoterm()
+        sale_order.onchange_partner_shipping_id()
         self.assertFalse(sale_order.incoterm)
         # Incoterm set only on delivery address
         sale_order.partner_shipping_id = customer_2
-        sale_order.onchange_partner_id_incoterm()
+        sale_order.onchange_partner_shipping_id()
         self.assertEqual(sale_order.incoterm, incoterm_exw)
         # Incoterm set only on customer
         sale_order.partner_id = customer_2
         sale_order.partner_shipping_id = customer_1
-        sale_order.onchange_partner_id_incoterm()
+        sale_order.onchange_partner_shipping_id()
         self.assertEqual(sale_order.incoterm, incoterm_exw)
         # Incoterm set on both partners
         sale_order.partner_shipping_id = customer_3
-        sale_order.onchange_partner_id_incoterm()
+        sale_order.onchange_partner_shipping_id()
         self.assertEqual(sale_order.incoterm, incoterm_fca)

--- a/sale_partner_incoterm_place/models/sale_order.py
+++ b/sale_partner_incoterm_place/models/sale_order.py
@@ -7,16 +7,17 @@ from odoo import models, api
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.onchange("partner_shipping_id", "partner_shipping_id")
-    def onchange_partner_id_incoterm(self):
-        super().onchange_partner_id_incoterm()
+    @api.onchange("partner_shipping_id", "partner_id")
+    def onchange_partner_shipping_id(self):
+        res = super().onchange_partner_shipping_id()
         if not self.partner_shipping_id:
             self.incoterm_place = False
-            return
+            return res
         if self.partner_shipping_id.sale_incoterm_id:
             self.incoterm_place = self.partner_shipping_id.sale_incoterm_place
         else:
             if not self.partner_id:
                 self.incoterm_place = False
-                return
+                return res
             self.incoterm_place = self.partner_id.sale_incoterm_place
+        return res


### PR DESCRIPTION
[1701](https://www.quartile.co/web?debug=1#id=1701&action=771&model=project.task&view_type=form&menu_id=505)

Before this change, the incoterms was not updated in the sales orders created through eCommerce as the custom onchange method was not being triggered there.  Therefore we switch to extend the standard method.

Here is the line that triggers the onchange method in website_sale module: https://github.com/odoo/odoo/blob/66a81ff5446daf97617d69a1ebca0cade4f27cdf/addons/website_sale/models/website.py#L294